### PR TITLE
fix(argo-cd): Fix Ingress version issue and update argocd role

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.2.2
+version: 4.2.3
 home: https://github.com/coreweave/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/coreweave-role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/coreweave-role.yaml
@@ -50,7 +50,13 @@ rules:
     resources:
       - virtualservers
     verbs:
-      - '*'
+      - create
+      - delete
+      - update
+      - patch
+      - get
+      - list
+      - watch
   - apiGroups:
       - argoproj.io
     resources:

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -19,11 +19,24 @@ spec:
     - host: {{ include "coreweave.externalDnsName" . }}
       http:
         paths:
-        - backend:
-            serviceName: {{ $serviceName }}
-            servicePort: {{ $servicePort }}
-          path: /
-          pathType: Prefix
+          - path: /
+            {{- if eq (include "argo-cd.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if eq (include "argo-cd.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if kindIs "float64" $servicePort }}
+                  number: {{ $servicePort }}
+                  {{- else }}
+                  name: {{ $servicePort }}
+                  {{- end }}
+              {{- else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
   tls:
     - hosts:
       - {{ include "coreweave.externalDnsName" . }}


### PR DESCRIPTION
* Fixes the Networking Ingress format, templates based on apiVersion correctly.
* Updates the access to VirtualServer resources in the argocd role
* Bump Chart version 4.2.3