### PR TITLE
fix(argo-cd): Fix helm deploy branch and bump chart 4.2.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ Helm push:
   stage: deploy
   only:
     refs:
-      - master
+      - coreweave
     changes:
       - .gitlab-ci.yml
       - charts/argo-cd/*

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.2.3
+version: 4.2.4
 home: https://github.com/coreweave/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:


### PR DESCRIPTION
* Fixing Helm Deploy branch to coreweave from master
* Bump chart to 4.2.4