### PR TITLE
fix(argo-cd): Fix argo-cd role for new permissions model

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.2.4
+version: 4.2.5
 home: https://github.com/coreweave/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/coreweave-role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/coreweave-role.yaml
@@ -5,15 +5,20 @@ metadata:
 rules:
   - apiGroups:
       - ""
+    resources:
+    - pods
+    - pods/log
+    - pods/portforward
+    - pods/exec
+    - pods/attach
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
       - extensions
       - apps
       - networking.k8s.io
     resources:
-      - pods
-      - pods/log
-      - pods/portforward
-      - pods/exec
-      - pods/attach
       - configmaps
       - endpoints
       - events


### PR DESCRIPTION
* Extracts pods resources into it's own rule for the argocd-full-access role. 

```yaml
  - apiGroups:
      - ""
    resources:
    - pods
    - pods/log
    - pods/portforward
    - pods/exec
    - pods/attach
    verbs:
      - "*"
```